### PR TITLE
Modernize 2/5: workout store + Home, Workout, and Info screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,17 @@
 
 ## Development
 
+This app relies on native modules (WebView, splash screen, etc.), so it needs a
+[development build](https://docs.expo.dev/develop/development-builds/introduction/)
+— it will not run in Expo Go.
+
 ```sh
-npm install      # install dependencies
-npx expo start   # start the dev server
+npm install       # install dependencies
+npx expo run:ios  # build and run the iOS development build (use run:android for Android)
 ```
 
-Then press `i` / `a` to open the iOS simulator or Android emulator, or scan the
-QR code with a development build.
+Once a development build is installed, `npx expo start` starts the dev server;
+press `i` / `a` to open it in the iOS simulator or Android emulator.
 
 ### Scripts
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,10 @@
 </h3>
 
 <p align="center">
-  A "One Punch Man"-inspired workout app!
+  A "One Punch Man"-inspired workout app: 100 push-ups, 100 sit-ups, 100 squats,
+  and a 10km run — every single day. Pick one of five intensity levels, work
+  through each exercise on a timer, and track your streak on the calendar.
 </p>
-
----
-
-[Get it on Expo!](https://expo.io/@datwheat/one-punch-fitness)
 
 ## Screenshots
 
@@ -24,12 +22,26 @@
   <img style="display:inline-block" alt="Settings Screen" src="./docs/images/settings.png" width="170">
 </p>
 
-## Key technologies used to build this
+## Development
 
-* [Expo](https://expo.io/)
-* [ReasonML](https://reasonml.github.io/)
-* [ReasonReact](https://reasonml.github.io/reason-react/) +
-  [Reductive](https://github.com/reasonml-community/reductive)
-* [styled-components](https://www.styled-components.com/)
-* [React Navigation](https://reactnavigation.org/)
-* [Figma](https://www.figma.com/) (for design)
+```sh
+npm install      # install dependencies
+npx expo start   # start the dev server
+```
+
+Then press `i` / `a` to open the iOS simulator or Android emulator, or scan the
+QR code with a development build.
+
+### Scripts
+
+```sh
+npm run lint       # eslint (eslint-config-expo), zero warnings tolerated
+npm run typecheck  # tsc --noEmit (strict)
+```
+
+## Built with
+
+- [Expo SDK 57](https://expo.dev/) + [React Native](https://reactnative.dev/)
+- [Expo Router](https://docs.expo.dev/router/introduction/) (typed routes, native tabs)
+- [TypeScript](https://www.typescriptlang.org/) (strict)
+- [Zustand](https://github.com/pmndrs/zustand) + AsyncStorage for persistence

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,48 @@
-import { Placeholder } from '@/components/placeholder';
+import { FlatList, ScrollView, StyleSheet, Text } from 'react-native';
+
+import { InfoCard } from '@/components/info-card';
+import { WorkoutCard } from '@/components/workout-card';
+import { colors } from '@/constants/colors';
+import { fonts } from '@/constants/fonts';
+import { guides } from '@/constants/guides';
 
 export default function HomeScreen() {
-  return <Placeholder label="home" />;
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      alwaysBounceVertical={false}
+      showsVerticalScrollIndicator={false}>
+      <WorkoutCard />
+      <Text style={styles.sectionLabel}>GUIDES (swipe left for more)</Text>
+      <FlatList
+        style={styles.guides}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        data={guides}
+        keyExtractor={(guide) => guide.id}
+        renderItem={({ item }) => <InfoCard guide={item} />}
+      />
+    </ScrollView>
+  );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.offWhite,
+    flex: 1,
+  },
+  content: {
+    flexGrow: 1,
+  },
+  sectionLabel: {
+    fontFamily: fonts.regular,
+    fontSize: 14,
+    marginLeft: 16,
+    color: colors.halfBlack,
+  },
+  guides: {
+    flexGrow: 0,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,28 @@
 import { Stack } from 'expo-router';
 import { DarkTheme, ThemeProvider } from 'expo-router/react-navigation';
+import * as SplashScreen from 'expo-splash-screen';
+import { useEffect, useState } from 'react';
 
 import { colors } from '@/constants/colors';
+import { useWorkoutStore } from '@/store/workout';
+
+// Keep the splash visible until the workout store has rehydrated so cold-start
+// taps can't act on pre-hydration state.
+SplashScreen.preventAutoHideAsync();
 
 // Inter fonts are embedded at build time via the expo-font config plugin (app.json),
 // so no runtime font loading is needed here.
 export default function RootLayout() {
+  const [hydrated, setHydrated] = useState(() => useWorkoutStore.persist.hasHydrated());
+
+  useEffect(() => useWorkoutStore.persist.onFinishHydration(() => setHydrated(true)), []);
+
+  useEffect(() => {
+    if (hydrated) SplashScreen.hideAsync();
+  }, [hydrated]);
+
+  if (!hydrated) return null;
+
   return (
     <ThemeProvider value={DarkTheme}>
       <Stack

--- a/app/info.tsx
+++ b/app/info.tsx
@@ -10,7 +10,13 @@ export default function InfoScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const guide = guides.find((g) => g.id === id);
 
-  if (!guide) return <View style={styles.container} />;
+  if (!guide) {
+    return (
+      <View style={[styles.container, styles.fallback]}>
+        <Text style={styles.fallbackText}>guide not found</Text>
+      </View>
+    );
+  }
 
   if (guide.url) {
     return (
@@ -43,6 +49,15 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: 'white',
+  },
+  fallback: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  fallbackText: {
+    color: colors.spotiBlack,
+    fontSize: 18,
+    fontFamily: fonts.regular,
   },
   loading: {
     position: 'absolute',

--- a/app/info.tsx
+++ b/app/info.tsx
@@ -1,5 +1,80 @@
-import { Placeholder } from '@/components/placeholder';
+import { useLocalSearchParams } from 'expo-router';
+import { ActivityIndicator, Image, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { WebView } from 'react-native-webview';
+
+import { colors } from '@/constants/colors';
+import { fonts } from '@/constants/fonts';
+import { guides } from '@/constants/guides';
 
 export default function InfoScreen() {
-  return <Placeholder label="info" />;
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const guide = guides.find((g) => g.id === id);
+
+  if (!guide) return <View style={styles.container} />;
+
+  if (guide.url) {
+    return (
+      <View style={styles.container}>
+        <WebView
+          source={{ uri: guide.url }}
+          startInLoadingState
+          renderLoading={() => (
+            <View style={styles.loading}>
+              <ActivityIndicator size="large" color={colors.status} />
+            </View>
+          )}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Image style={styles.hero} source={guide.coverImage} resizeMode="cover" />
+      <ScrollView style={styles.textContent}>
+        <Text style={styles.title}>{guide.title}</Text>
+        <Text style={styles.description}>{guide.content}</Text>
+      </ScrollView>
+    </View>
+  );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'white',
+  },
+  loading: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  hero: {
+    flex: 0.4,
+    borderTopRightRadius: 12,
+    borderTopLeftRadius: 12,
+    width: '100%',
+  },
+  textContent: {
+    flex: 1,
+    paddingHorizontal: 24,
+  },
+  title: {
+    color: colors.spotiBlack,
+    fontSize: 24,
+    fontFamily: fonts.medium,
+    marginTop: 24,
+    backgroundColor: 'transparent',
+  },
+  description: {
+    color: colors.spotiBlack,
+    fontSize: 18,
+    fontFamily: fonts.regular,
+    marginVertical: 16,
+    backgroundColor: 'transparent',
+  },
+});

--- a/app/workout.tsx
+++ b/app/workout.tsx
@@ -1,5 +1,280 @@
-import { Placeholder } from '@/components/placeholder';
+import { useKeepAwake } from 'expo-keep-awake';
+import { router } from 'expo-router';
+import { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Dimensions,
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { colors } from '@/constants/colors';
+import { fonts } from '@/constants/fonts';
+import { illustrations } from '@/constants/illustrations';
+import { routines } from '@/constants/routines';
+import { currentExercise, useWorkoutStore, type Exercise } from '@/store/workout';
+
+const WIDTH = Dimensions.get('window').width;
+const TIMER_SIZE = WIDTH * 0.6;
+
+type TimerStatus = 'active' | 'paused' | 'stopped';
+
+const exerciseImages: Record<Exercise, number> = {
+  pushUps: illustrations.pushups,
+  sitUps: illustrations.situps,
+  squats: illustrations.squats,
+  run: illustrations.run,
+};
+
+const exerciseNames: Record<Exercise, string> = {
+  pushUps: 'push-ups',
+  sitUps: 'sit-ups',
+  squats: 'squats',
+  run: 'run',
+};
+
+function formatTime(seconds: number): string {
+  const mm = `${Math.floor(seconds / 60)}`.padStart(2, '0');
+  const ss = `${seconds % 60}`.padStart(2, '0');
+  return `${mm}:${ss}`;
+}
 
 export default function WorkoutScreen() {
-  return <Placeholder label="workout" />;
+  useKeepAwake();
+
+  const currentWorkout = useWorkoutStore((s) => s.currentWorkout);
+  const completeSet = useWorkoutStore((s) => s.completeSet);
+  const completeWorkout = useWorkoutStore((s) => s.completeWorkout);
+
+  const exercise = currentExercise(currentWorkout);
+  const routine = routines[currentWorkout.level];
+
+  const [inSession, setInSession] = useState(false);
+  const [timeUsed, setTimeUsed] = useState(0);
+  const [status, setStatus] = useState<TimerStatus>('active');
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const statusRef = useRef<TimerStatus>(status);
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
+  const stopInterval = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+
+  const startInterval = () => {
+    stopInterval();
+    intervalRef.current = setInterval(() => {
+      if (statusRef.current !== 'paused') setTimeUsed((t) => t + 1);
+    }, 1000);
+  };
+
+  // Clear the interval when leaving the screen.
+  useEffect(() => stopInterval, []);
+
+  const onAction = () => {
+    if (inSession) {
+      stopInterval();
+      completeSet(exercise, timeUsed);
+      if (exercise === 'run') {
+        completeWorkout();
+        Alert.alert('Congrats!', "You've completed today's workout. Rock on!");
+        router.back();
+      }
+      setInSession(false);
+      setStatus('active');
+      setTimeUsed(0);
+    } else {
+      setTimeUsed(0);
+      setStatus('active');
+      startInterval();
+      setInSession(true);
+    }
+  };
+
+  const onSessionControl = () => {
+    if (status === 'active') {
+      setStatus('paused');
+    } else if (status === 'paused') {
+      setStatus('active');
+    } else {
+      setTimeUsed(0);
+      setStatus('active');
+      startInterval();
+    }
+  };
+
+  const onStop = () => {
+    stopInterval();
+    setStatus('stopped');
+  };
+
+  const sessionControlLabel =
+    status === 'active' ? 'PAUSE' : status === 'paused' ? 'RESUME' : 'START';
+
+  const showProgress = exercise !== 'run';
+  const reps =
+    exercise === 'run'
+      ? `${routine.run.distance}${routine.run.units}`
+      : `${routine[exercise].reps}`;
+  const progressText =
+    exercise === 'run'
+      ? ''
+      : `set ${currentWorkout.setsCompleted[exercise] + 1} of ${routine[exercise].sets}`;
+
+  const setInfo = (
+    <Text style={styles.setType}>
+      <Text style={styles.setReps}>{reps}</Text>
+      {` ${exerciseNames[exercise]}`}
+    </Text>
+  );
+
+  return (
+    <View style={styles.background}>
+      <ScrollView
+        contentContainerStyle={styles.content}
+        alwaysBounceVertical={false}
+        showsVerticalScrollIndicator={false}>
+        <View style={styles.container}>
+          {inSession ? (
+            <>
+              {setInfo}
+              <View style={styles.timer}>
+                <Text style={styles.timerText}>{formatTime(timeUsed)}</Text>
+              </View>
+              {showProgress ? <Text style={styles.progress}>{progressText}</Text> : null}
+              <View style={styles.controlGroup}>
+                <TouchableOpacity style={styles.control} activeOpacity={0.75} onPress={onSessionControl}>
+                  <View style={styles.controlBase}>
+                    <Text style={[styles.controlLabel, { color: colors.blueLeftUsTooSoon }]}>
+                      {sessionControlLabel}
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+                <TouchableOpacity style={styles.control} activeOpacity={0.75} onPress={onStop}>
+                  <View style={styles.controlBase}>
+                    <Text style={[styles.controlLabel, { color: colors.bRED }]}>STOP</Text>
+                  </View>
+                </TouchableOpacity>
+              </View>
+            </>
+          ) : (
+            <>
+              <Image style={styles.image} source={exerciseImages[exercise]} resizeMode="cover" />
+              {showProgress ? <Text style={styles.progress}>{progressText}</Text> : null}
+              {setInfo}
+            </>
+          )}
+          <TouchableOpacity style={styles.action} activeOpacity={0.75} onPress={onAction}>
+            <View style={styles.actionBase}>
+              <Text style={styles.actionLabel}>{inSession ? 'COMPLETE' : 'GO'}</Text>
+            </View>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </View>
+  );
 }
+
+const styles = StyleSheet.create({
+  background: {
+    flex: 1,
+    backgroundColor: '#faf8ff',
+  },
+  content: {
+    flexGrow: 1,
+  },
+  container: {
+    flex: 1,
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 16,
+  },
+  image: {
+    width: WIDTH - 32,
+    height: WIDTH * 0.7,
+    borderRadius: 12,
+  },
+  progress: {
+    fontFamily: fonts.regular,
+    fontSize: 14,
+    textAlign: 'center',
+    color: colors.halfBlack,
+    marginTop: 16,
+  },
+  setType: {
+    fontFamily: fonts.regular,
+    fontSize: 36,
+    textAlign: 'center',
+    color: colors.status,
+    marginVertical: 8,
+  },
+  setReps: {
+    fontFamily: fonts.bold,
+    fontSize: 36,
+    textAlign: 'center',
+    color: colors.status,
+  },
+  timer: {
+    width: TIMER_SIZE,
+    height: TIMER_SIZE,
+    borderRadius: TIMER_SIZE / 2,
+    borderWidth: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderColor: colors.status,
+  },
+  timerText: {
+    fontFamily: fonts.regular,
+    backgroundColor: 'transparent',
+    fontSize: 64,
+    color: colors.spotiBlack,
+    textAlign: 'center',
+  },
+  controlGroup: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    alignSelf: 'stretch',
+  },
+  control: {
+    width: '50%',
+  },
+  controlBase: {
+    marginHorizontal: 16,
+    backgroundColor: 'transparent',
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignSelf: 'stretch',
+  },
+  controlLabel: {
+    fontFamily: fonts.bold,
+    fontSize: 36,
+    textAlign: 'center',
+  },
+  action: {
+    width: '100%',
+  },
+  actionBase: {
+    marginHorizontal: 16,
+    backgroundColor: colors.start,
+    borderRadius: 12,
+    paddingVertical: 8,
+    alignSelf: 'stretch',
+  },
+  actionLabel: {
+    fontFamily: fonts.bold,
+    fontSize: 36,
+    color: 'white',
+    backgroundColor: 'transparent',
+    textAlign: 'center',
+  },
+});

--- a/components/info-card.tsx
+++ b/components/info-card.tsx
@@ -1,0 +1,93 @@
+import { Feather } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
+import { router } from 'expo-router';
+import {
+  Dimensions,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { colors } from '@/constants/colors';
+import { fonts } from '@/constants/fonts';
+import type { Guide } from '@/constants/guides';
+
+const CARD_WIDTH = Dimensions.get('window').width - 16;
+
+export function InfoCard({ guide }: { guide: Guide }) {
+  return (
+    <TouchableOpacity
+      activeOpacity={0.9}
+      onPress={() => router.push({ pathname: '/info', params: { id: guide.id } })}>
+      <View style={styles.container}>
+        <View>
+          <Image
+            style={styles.cover}
+            source={guide.coverImage}
+            resizeMode="cover"
+          />
+          <LinearGradient
+            style={styles.gradient}
+            colors={['rgba(0,0,0,0)', colors.spotiBlack]}
+          />
+          <Text style={styles.title}>{guide.title}</Text>
+          {guide.url ? (
+            <View style={styles.linkIcon}>
+              <Feather name="link" size={16} color="white" />
+            </View>
+          ) : null}
+        </View>
+        <Text style={styles.description}>{guide.shortDescription}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'white',
+    width: CARD_WIDTH,
+    marginHorizontal: 8,
+    marginVertical: 8,
+    overflow: 'hidden',
+    borderRadius: 12,
+  },
+  cover: {
+    height: 148,
+    width: '100%',
+    borderTopRightRadius: 12,
+    borderTopLeftRadius: 12,
+  },
+  gradient: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    height: 148,
+  },
+  title: {
+    color: 'white',
+    fontSize: 24,
+    fontFamily: fonts.medium,
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    bottom: 16,
+    backgroundColor: 'transparent',
+  },
+  linkIcon: {
+    position: 'absolute',
+    backgroundColor: 'transparent',
+    top: 16,
+    right: 16,
+  },
+  description: {
+    fontFamily: fonts.regular,
+    backgroundColor: 'transparent',
+    fontSize: 12,
+    color: colors.spotiBlack,
+    margin: 16,
+  },
+});

--- a/components/workout-card.tsx
+++ b/components/workout-card.tsx
@@ -40,6 +40,8 @@ function IntensityButton({
   return (
     <TouchableOpacity
       style={[styles.intensityTouchable, side === 'left' ? styles.left : styles.right]}
+      accessibilityRole="button"
+      accessibilityLabel={icon === 'minus' ? 'decrease intensity' : 'increase intensity'}
       disabled={disabled}
       onPress={onPress}>
       <View style={[styles.intensityBase, disabled && styles.intensityDisabled]}>

--- a/components/workout-card.tsx
+++ b/components/workout-card.tsx
@@ -1,0 +1,206 @@
+import { Feather } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
+import { router } from 'expo-router';
+import {
+  Dimensions,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+import { colors } from '@/constants/colors';
+import { fonts } from '@/constants/fonts';
+import { illustrations } from '@/constants/illustrations';
+import { routines } from '@/constants/routines';
+import { useWorkoutStore } from '@/store/workout';
+
+const CARD_WIDTH = Dimensions.get('window').width - 16;
+
+const levelCovers = [
+  illustrations.workoutLevel1,
+  illustrations.workoutLevel2,
+  illustrations.workoutLevel3,
+  illustrations.workoutLevel4,
+  illustrations.workoutLevel5,
+];
+
+function IntensityButton({
+  icon,
+  side,
+  disabled,
+  onPress,
+}: {
+  icon: 'minus' | 'plus';
+  side: 'left' | 'right';
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <TouchableOpacity
+      style={[styles.intensityTouchable, side === 'left' ? styles.left : styles.right]}
+      disabled={disabled}
+      onPress={onPress}>
+      <View style={[styles.intensityBase, disabled && styles.intensityDisabled]}>
+        <Feather name={icon} color="white" size={18} />
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+function RoutineFacet({ amount, name }: { amount: string; name: string }) {
+  return (
+    <View style={styles.facet}>
+      <Text style={styles.facetAmount}>{amount}</Text>
+      <Text style={styles.facetName}>{` ${name}`}</Text>
+    </View>
+  );
+}
+
+export function WorkoutCard() {
+  const currentWorkout = useWorkoutStore((s) => s.currentWorkout);
+  const incrementLevel = useWorkoutStore((s) => s.incrementLevel);
+  const decrementLevel = useWorkoutStore((s) => s.decrementLevel);
+  const startWorkout = useWorkoutStore((s) => s.startWorkout);
+
+  const { level, started, completed } = currentWorkout;
+  const routine = routines[level];
+
+  const startLabel = completed ? 'completed' : started ? 'resume' : 'start';
+
+  const onStart = () => {
+    startWorkout();
+    router.push('/workout');
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Image style={styles.cover} source={levelCovers[level]} resizeMode="cover" />
+        <LinearGradient
+          style={styles.gradient}
+          colors={['rgba(0,0,0,0)', colors.spotiBlack]}
+        />
+        <Text style={styles.levelLabel}>{`level ${level + 1}`}</Text>
+        <IntensityButton
+          icon="minus"
+          side="left"
+          disabled={started || level === 0}
+          onPress={decrementLevel}
+        />
+        <IntensityButton
+          icon="plus"
+          side="right"
+          disabled={started || level === 4}
+          onPress={incrementLevel}
+        />
+      </View>
+      <View style={styles.routineContainer}>
+        <View>
+          <RoutineFacet amount={`${routine.pushUps.sets}x${routine.pushUps.reps}`} name="push-ups" />
+          <RoutineFacet amount={`${routine.sitUps.sets}x${routine.sitUps.reps}`} name="sit-ups" />
+        </View>
+        <View>
+          <RoutineFacet amount={`${routine.squats.sets}x${routine.squats.reps}`} name="squats" />
+          <RoutineFacet amount={`${routine.run.distance}${routine.run.units}`} name="run" />
+        </View>
+      </View>
+      <View style={styles.startContainer}>
+        <TouchableOpacity style={styles.startTouchable} disabled={completed} onPress={onStart}>
+          <Text style={styles.startLabel}>{startLabel}</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'white',
+    width: CARD_WIDTH,
+    marginHorizontal: 8,
+    marginVertical: 8,
+    overflow: 'hidden',
+    borderRadius: 12,
+  },
+  header: {
+    alignItems: 'center',
+  },
+  cover: {
+    height: 200,
+    width: '100%',
+    borderTopRightRadius: 12,
+    borderTopLeftRadius: 12,
+  },
+  gradient: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    height: 200,
+  },
+  levelLabel: {
+    color: 'white',
+    fontSize: 24,
+    fontFamily: fonts.medium,
+    backgroundColor: 'transparent',
+    position: 'absolute',
+    bottom: 18,
+  },
+  intensityTouchable: {
+    position: 'absolute',
+    bottom: 16,
+  },
+  left: { left: 16 },
+  right: { right: 16 },
+  intensityBase: {
+    height: 32,
+    width: 32,
+    borderRadius: 8,
+    overflow: 'hidden',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.twentyWhite,
+  },
+  intensityDisabled: { opacity: 0.3 },
+  routineContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    margin: 16,
+  },
+  facet: {
+    flexDirection: 'row',
+  },
+  facetAmount: {
+    fontFamily: fonts.bold,
+    color: colors.spotiBlack,
+    fontSize: 14,
+  },
+  facetName: {
+    fontFamily: fonts.regular,
+    color: colors.spotiBlack,
+    fontSize: 14,
+  },
+  startContainer: {
+    height: 64,
+    backgroundColor: colors.start,
+    borderBottomRightRadius: 12,
+    borderBottomLeftRadius: 12,
+  },
+  startTouchable: {
+    backgroundColor: colors.twentyOnStart,
+    borderRadius: 8,
+    flex: 1,
+    margin: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  startLabel: {
+    fontFamily: fonts.medium,
+    fontSize: 16,
+    color: 'white',
+    backgroundColor: 'transparent',
+  },
+});

--- a/constants/guides.ts
+++ b/constants/guides.ts
@@ -30,7 +30,7 @@ export const guides: Guide[] = [
       ' And of course, make sure you eat three meals a day. ' +
       'Just a banana in the morning is fine. But the most important thing is ' +
       ' to never use the a.c. or heat in the summer or winter ' +
-      'so that you can strenghten the mind. ' +
+      'so that you can strengthen the mind. ' +
       "In the beginning, you'll wish you were dead. " +
       "You might start thinking, what's the harm of taking a day off? " +
       'But for me, in order to be a strong hero, no matter how tough it was even if I was spitting blood, I never stopped. ' +

--- a/constants/guides.ts
+++ b/constants/guides.ts
@@ -1,0 +1,58 @@
+import type { ImageSourcePropType } from 'react-native';
+
+import { illustrations } from './illustrations';
+
+// Ported verbatim from the legacy src/config/Info.re (including Saitama's
+// monologue). Each guide has a stable `id` so routes can reference a card by
+// id — route params are strings, so /info looks the card up by id rather than
+// receiving require() numbers or long text through navigation params.
+export interface Guide {
+  id: string;
+  coverImage: ImageSourcePropType;
+  title: string;
+  shortDescription: string;
+  content?: string;
+  url?: string;
+}
+
+export const guides: Guide[] = [
+  {
+    id: 'saitamas-secret',
+    coverImage: illustrations.theSecretSauce,
+    title: "What is Saitama's secret?",
+    shortDescription: 'Learn about this routine from Saitama himself!',
+    content:
+      "First, what's important is to make sure you stick to this intense training regimen." +
+      ' You just have to keep doing it. No matter how hard it gets. ' +
+      'It took me three years to get this strong. ' +
+      'One hundred push-ups! One hundred sit-ups! One hundred squats! ' +
+      'Then a 10 kilometer run! Every single day!' +
+      ' And of course, make sure you eat three meals a day. ' +
+      'Just a banana in the morning is fine. But the most important thing is ' +
+      ' to never use the a.c. or heat in the summer or winter ' +
+      'so that you can strenghten the mind. ' +
+      "In the beginning, you'll wish you were dead. " +
+      "You might start thinking, what's the harm of taking a day off? " +
+      'But for me, in order to be a strong hero, no matter how tough it was even if I was spitting blood, I never stopped. ' +
+      'I kept doing squats even when my legs were so heavy they refused to move. ' +
+      'Even when my arms started making weird clicking noises, I kept doing push-ups. ' +
+      'A year and a half later, I started to notice a difference. ' +
+      'I was bald ... and I had become stronger. ' +
+      'In other words, you gotta train like hell to the point where your hair falls out.' +
+      ' That\'s the only way to become strong.\n\n- Saitama,\n\t"Someone who is a hero for fun."',
+  },
+  {
+    id: 'proper-pushups',
+    coverImage: illustrations.properPushups,
+    title: 'Proper Push-Up Technique',
+    shortDescription: "Make sure you're training your arms the right way!",
+    url: 'https://www.livestrong.com/article/32382-proper-pushup-technique/',
+  },
+  {
+    id: 'wrist-mobility',
+    coverImage: illustrations.wristsHurtPushup,
+    title: 'A Wrist Mobility Drill',
+    shortDescription: "Don't let your joints tap out before your muscles!",
+    url: 'https://www.instagram.com/p/4Wf-bgMEVm/',
+  },
+];

--- a/constants/routines.ts
+++ b/constants/routines.ts
@@ -1,0 +1,30 @@
+// Ported verbatim from the legacy src/config/Routines.re.
+// Index = workout level (0..4). push-ups/sit-ups/squats share sets/reps per
+// level; the run is always 10km.
+export interface RepWorkout {
+  sets: number;
+  reps: number;
+}
+
+export interface DistanceWorkout {
+  distance: number;
+  units: string;
+}
+
+export interface Variation {
+  pushUps: RepWorkout;
+  sitUps: RepWorkout;
+  squats: RepWorkout;
+  run: DistanceWorkout;
+}
+
+const rep = (sets: number, reps: number): RepWorkout => ({ sets, reps });
+const run: DistanceWorkout = { distance: 10, units: 'km' };
+
+export const routines: Variation[] = [
+  { pushUps: rep(10, 10), sitUps: rep(10, 10), squats: rep(10, 10), run },
+  { pushUps: rep(5, 20), sitUps: rep(5, 20), squats: rep(5, 20), run },
+  { pushUps: rep(4, 25), sitUps: rep(4, 25), squats: rep(4, 25), run },
+  { pushUps: rep(2, 50), sitUps: rep(2, 50), squats: rep(2, 50), run },
+  { pushUps: rep(1, 100), sitUps: rep(1, 100), squats: rep(1, 100), run },
+];

--- a/lib/dates.ts
+++ b/lib/dates.ts
@@ -1,0 +1,8 @@
+// Local calendar date as "YYYY-MM-DD" (matches the legacy Progenitor.dateString,
+// which used the device's local Date fields — not UTC).
+export function localDate(date: Date = new Date()): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1194,10 +1194,35 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3567,40 +3592,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
@@ -5398,7 +5389,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,22 @@
       "name": "one-punch-fitness",
       "version": "0.5.1",
       "dependencies": {
+        "@expo/vector-icons": "^15.0.2",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "expo": "^57.0.6",
         "expo-constants": "~57.0.5",
         "expo-font": "~57.0.1",
+        "expo-keep-awake": "~57.0.1",
+        "expo-linear-gradient": "~57.0.1",
         "expo-linking": "~57.0.3",
         "expo-router": "~57.0.6",
         "expo-splash-screen": "~57.0.4",
         "react": "19.2.3",
         "react-native": "0.86.0",
         "react-native-safe-area-context": "~5.7.0",
-        "react-native-screens": "4.25.2"
+        "react-native-screens": "4.25.2",
+        "react-native-webview": "13.16.1",
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@types/react": "~19.2.4",
@@ -1188,31 +1194,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1905,6 +1886,17 @@
         }
       }
     },
+    "node_modules/@expo/vector-icons": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
+      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@expo/xcpretty": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.4.tgz",
@@ -2536,6 +2528,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native-masked-view/masked-view": {
@@ -5360,6 +5364,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5707,6 +5712,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-57.0.6.tgz",
       "integrity": "sha512-4NKM1ArfRAmmY82Xcw/guGHlTSItD5mzNxbK4Qd3aOPuRAPAkCgJVLC/eqccZCEGS5aJn0tyjHNKE65k2GrcFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "^57.0.8",
@@ -5837,6 +5843,17 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-57.0.1.tgz",
+      "integrity": "sha512-CpS8eMqoIWcHVGKV66zbDvzotCw9qYp3f8CuI9N+h1LaO0tMLUzBpkhAKePUsXlpN3yolYlHFSPkfVZ/uSh+iA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {
@@ -7254,6 +7271,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8146,6 +8172,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -9590,6 +9628,21 @@
       "peerDependencies": {
         "react": "*",
         "react-native": ">=0.82.0"
+      }
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.16.1",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.1.tgz",
+      "integrity": "sha512-If0eHhoEdOYDcHsX+xBFwHMbWBGK1BvGDQDQdVkwtSIXiq1uiqjkpWVP2uQ1as94J0CzvFE9PUNDuhiX0Z6ubw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-worklets": {
@@ -11508,6 +11561,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1195,9 +1195,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3565,6 +3565,40 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {

--- a/package.json
+++ b/package.json
@@ -13,16 +13,22 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@expo/vector-icons": "^15.0.2",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "expo": "^57.0.6",
     "expo-constants": "~57.0.5",
     "expo-font": "~57.0.1",
+    "expo-keep-awake": "~57.0.1",
+    "expo-linear-gradient": "~57.0.1",
     "expo-linking": "~57.0.3",
     "expo-router": "~57.0.6",
     "expo-splash-screen": "~57.0.4",
     "react": "19.2.3",
     "react-native": "0.86.0",
     "react-native-safe-area-context": "~5.7.0",
-    "react-native-screens": "4.25.2"
+    "react-native-screens": "4.25.2",
+    "react-native-webview": "13.16.1",
+    "zustand": "^5.0.14"
   },
   "overrides": {
     "react-dom": "19.2.3"

--- a/store/workout.ts
+++ b/store/workout.ts
@@ -1,0 +1,173 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+import { persist, type PersistStorage } from 'zustand/middleware';
+
+import { routines } from '@/constants/routines';
+import { localDate } from '@/lib/dates';
+
+// Exercises. The three rep-based ones are grouped as `RepExercise`; `run` is
+// tracked separately (a single boolean + time rather than a counter + array).
+export type RepExercise = 'pushUps' | 'sitUps' | 'squats';
+export type Exercise = RepExercise | 'run';
+
+export interface SetsCompleted {
+  pushUps: number;
+  sitUps: number;
+  squats: number;
+  run: boolean;
+}
+
+export interface TimeUsedPerSet {
+  pushUps: number[];
+  sitUps: number[];
+  squats: number[];
+  run: number;
+}
+
+export interface Workout {
+  level: number;
+  date: string;
+  started: boolean;
+  completed: boolean;
+  setsCompleted: SetsCompleted;
+  timeUsedPerSet: TimeUsedPerSet;
+}
+
+// The persisted slice, stored raw under "@state" — exactly the legacy JSON
+// shape `{ currentWorkout, history }` (no zustand `{ state, version }` envelope).
+export interface Persisted {
+  currentWorkout: Workout;
+  history: Workout[];
+}
+
+interface WorkoutStore extends Persisted {
+  incrementLevel: () => void;
+  decrementLevel: () => void;
+  startWorkout: () => void;
+  completeWorkout: () => void;
+  completeSet: (exercise: Exercise, seconds: number) => void;
+  rolloverIfNeeded: () => void;
+  reset: () => void;
+}
+
+function genNewWorkout(level: number): Workout {
+  return {
+    level,
+    date: localDate(),
+    started: false,
+    completed: false,
+    setsCompleted: { pushUps: 0, sitUps: 0, squats: 0, run: false },
+    timeUsedPerSet: { pushUps: [], sitUps: [], squats: [], run: 0 },
+  };
+}
+
+// A custom PersistStorage keeps the on-disk value as the raw legacy shape.
+// getItem accepts a raw legacy payload (what existing users already have at
+// "@state") by wrapping it in the StorageValue envelope zustand expects;
+// setItem unwraps it so we keep writing the raw shape going forward.
+const storage: PersistStorage<Persisted> = {
+  getItem: async (name) => {
+    const raw = await AsyncStorage.getItem(name);
+    if (!raw) return null;
+    return { state: JSON.parse(raw) as Persisted, version: 0 };
+  },
+  setItem: async (name, value) => {
+    await AsyncStorage.setItem(name, JSON.stringify(value.state));
+  },
+  removeItem: (name) => AsyncStorage.removeItem(name),
+};
+
+export const useWorkoutStore = create<WorkoutStore>()(
+  persist<WorkoutStore, [], [], Persisted>(
+    (set) => ({
+      currentWorkout: genNewWorkout(0),
+      history: [],
+      incrementLevel: () =>
+        set((s) => ({
+          currentWorkout: {
+            ...s.currentWorkout,
+            level: Math.min(4, s.currentWorkout.level + 1),
+          },
+        })),
+      decrementLevel: () =>
+        set((s) => ({
+          currentWorkout: {
+            ...s.currentWorkout,
+            level: Math.max(0, s.currentWorkout.level - 1),
+          },
+        })),
+      startWorkout: () =>
+        set((s) => ({ currentWorkout: { ...s.currentWorkout, started: true } })),
+      completeWorkout: () =>
+        set((s) => ({ currentWorkout: { ...s.currentWorkout, completed: true } })),
+      completeSet: (exercise, seconds) =>
+        set((s) => {
+          const w = s.currentWorkout;
+          if (exercise === 'run') {
+            return {
+              currentWorkout: {
+                ...w,
+                setsCompleted: { ...w.setsCompleted, run: true },
+                timeUsedPerSet: { ...w.timeUsedPerSet, run: seconds },
+              },
+            };
+          }
+          return {
+            currentWorkout: {
+              ...w,
+              setsCompleted: {
+                ...w.setsCompleted,
+                [exercise]: w.setsCompleted[exercise] + 1,
+              },
+              timeUsedPerSet: {
+                ...w.timeUsedPerSet,
+                [exercise]: [...w.timeUsedPerSet[exercise], seconds],
+              },
+            },
+          };
+        }),
+      // If the persisted current workout is from an earlier day, archive it and
+      // start a fresh workout at the same level. Runs after rehydration and can
+      // be called again when the app foregrounds on a new day.
+      rolloverIfNeeded: () =>
+        set((s) => {
+          if (s.currentWorkout.date === localDate()) return {};
+          return {
+            history: [...s.history, s.currentWorkout],
+            currentWorkout: genNewWorkout(s.currentWorkout.level),
+          };
+        }),
+      reset: () => set({ currentWorkout: genNewWorkout(0), history: [] }),
+    }),
+    {
+      name: '@state',
+      storage,
+      partialize: (s) => ({ currentWorkout: s.currentWorkout, history: s.history }),
+      onRehydrateStorage: () => (state) => state?.rolloverIfNeeded(),
+    },
+  ),
+);
+
+// Selectors / pure helpers.
+
+// First exercise in order push-ups -> sit-ups -> squats whose completed sets
+// are still below the level's target; otherwise the run.
+export function currentExercise(workout: Workout): Exercise {
+  const routine = routines[workout.level];
+  if (workout.setsCompleted.pushUps < routine.pushUps.sets) return 'pushUps';
+  if (workout.setsCompleted.sitUps < routine.sitUps.sets) return 'sitUps';
+  if (workout.setsCompleted.squats < routine.squats.sets) return 'squats';
+  return 'run';
+}
+
+// Mean of the four exercise fractions, as a 0..100 percentage.
+export function percentComplete(workout: Workout): number {
+  const routine = routines[workout.level];
+  const fractions = [
+    workout.setsCompleted.pushUps / routine.pushUps.sets,
+    workout.setsCompleted.sitUps / routine.sitUps.sets,
+    workout.setsCompleted.squats / routine.squats.sets,
+    workout.setsCompleted.run ? 1 : 0,
+  ];
+  return (fractions.reduce((sum, f) => sum + f, 0) / fractions.length) * 100;
+}

--- a/store/workout.ts
+++ b/store/workout.ts
@@ -104,6 +104,7 @@ export const useWorkoutStore = create<WorkoutStore>()(
         set((s) => {
           const w = s.currentWorkout;
           if (exercise === 'run') {
+            if (w.setsCompleted.run) return {};
             return {
               currentWorkout: {
                 ...w,
@@ -112,6 +113,7 @@ export const useWorkoutStore = create<WorkoutStore>()(
               },
             };
           }
+          if (w.setsCompleted[exercise] >= routines[w.level][exercise].sets) return {};
           return {
             currentWorkout: {
               ...w,


### PR DESCRIPTION
Stacked on #22. Ports the app's core: state, Home, Workout, and the Info detail route.

## What
- **Workout store** (`store/workout.ts`): zustand + persist. Critically, a custom `PersistStorage` adapter keeps the on-disk value at the legacy `"@state"` AsyncStorage key in the raw legacy JSON shape (`{currentWorkout, history}`) — existing users' workout history survives the rewrite, with no `{state, version}` envelope ever written. Day rollover archives yesterday's workout on rehydrate.
- **Routines/guides constants**: level table (10×10 … 1×100 + 10km run) and guide content ported verbatim from the ReasonML source; guides get stable string ids so routes pass ids, not payloads.
- **Home**: WorkoutCard (per-level cover + gradient, intensity ± buttons with legacy disable rules, routine facets, start/resume/completed) and the horizontal paging guides carousel.
- **Workout**: transition + in-session layouts, mm:ss timer (pause/resume/stop), COMPLETE dispatches per-set time; finishing the run completes the workout with the legacy "Rock on!" alert; keep-awake while open.
- **Info**: webview for link guides, hero + text for content guides.
- README rewritten for the new stack.

## Verification
- lint (zero warnings), typecheck (strict, no `any`), `expo export --platform ios` all clean.

Fidelity note: one legacy quirk was intentionally fixed — the old screen displayed `sitUps.reps` for every rep exercise; the port shows the actual exercise's reps (identical values in practice at every level).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the app’s core to the SDK 57 scaffold: adds a `zustand` workout store with legacy persistence and rebuilds Home, Workout, and Info screens for a complete modern flow. Regenerates `package-lock.json` from scratch to include platform-conditional optional deps so `npm ci` runs cleanly on Linux CI.

- **New Features**
  - Workout state: `zustand` + persist via a custom storage adapter that reads/writes the legacy `@state` JSON; day rollover archives yesterday’s workout on rehydrate; guards prevent over-completing sets and double-completing the run.
  - Home: WorkoutCard (level cover, intensity ± with legacy disable rules and a11y labels, routine facets, start/resume/completed) and a horizontal guides carousel.
  - Workout: in-session and transition layouts, mm:ss timer with pause/resume/stop, per-set time capture, run completion flow with alert, `expo-keep-awake` while open.
  - Info: web guides open in `react-native-webview`; content guides render a hero image and text; guides use stable string ids for routing; shows a simple fallback if a guide id is missing.
  - App shell: keeps the splash screen up until the store rehydrates so cold-start taps can’t act on pre-hydration state.

- **Migration**
  - No steps required. Data stays in the raw legacy JSON at `@state` (no `{state, version}` envelope), so existing histories rehydrate unchanged.
  - Minor fidelity fix: show the correct reps label for each exercise instead of always using sit-ups.

<sup>Written for commit 8193dfa532009c201a23feb9a75b873fb29d78bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FiberJW/one-punch-fitness/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

