### PR TITLE
Modernize 4/5: EAS project + dev-client builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ web-build/
 expo-env.d.ts
 
 # Native
+/ios
+/android
 *.jks
 *.p8
 *.p12

--- a/app.json
+++ b/app.json
@@ -53,6 +53,13 @@
     ],
     "experiments": {
       "typedRoutes": true
-    }
+    },
+    "extra": {
+      "router": {},
+      "eas": {
+        "projectId": "babbfa81-37b4-41ad-9d36-0405aabe5e49"
+      }
+    },
+    "owner": "fiberjw"
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,20 @@
+{
+  "cli": {
+    "version": ">= 18.11.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-native-community/datetimepicker": "9.1.0",
         "expo": "^57.0.6",
         "expo-constants": "~57.0.5",
+        "expo-dev-client": "~57.0.6",
         "expo-font": "~57.0.1",
         "expo-keep-awake": "~57.0.1",
         "expo-linear-gradient": "~57.0.1",
@@ -5864,6 +5865,59 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-dev-client": {
+      "version": "57.0.6",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-57.0.6.tgz",
+      "integrity": "sha512-15EN+qsd5CoIt2Mke0Hvah4GR5OgLOC2dJr74LBd9gPEtGeyx1YL1hd4AEKK/OGfD7Iy4Gohe/mKQp6TW538Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "~57.0.6",
+        "expo-dev-menu": "~57.0.6",
+        "expo-dev-menu-interface": "~57.0.0",
+        "expo-manifests": "~57.0.0",
+        "expo-updates-interface": "~57.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "57.0.6",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-57.0.6.tgz",
+      "integrity": "sha512-abCoERL908FDHrVq7i2of84ZW0fDbArH4IHa2rcN6tsYMlhEZu1Vi3ytkMQ4vYtqzpsMEwisHm5JkxPbvf5Dlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^57.0.1",
+        "expo-dev-menu": "~57.0.6",
+        "expo-manifests": "~57.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "57.0.6",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-57.0.6.tgz",
+      "integrity": "sha512-P8NaBfo5i8E2P4qDALZxpoLy7Px9BXMWnl7D6FmyJB5B2EyrRVDmvy6QtjRZrTrVnznGzUVBYRZtpUOxgGA1NA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "~57.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "57.0.0",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-57.0.0.tgz",
+      "integrity": "sha512-F47VdzOHYc19FhI/jBgctpO8a5UskTIxG6a1E5t3W5gF8VImuvBQffdXXfLHhsuCl7dS3v3U0R45cleeVXO1Zg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-file-system": {
       "version": "57.0.1",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-57.0.1.tgz",
@@ -5900,6 +5954,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-57.0.1.tgz",
+      "integrity": "sha512-cgTe1NqzQdYs/WN+3nIY5IZg8s0pb0xaTUbhYvxQDn137GbwRfHoGM2se3m3Vsl4Qu+B9G4RPEK5WJDEU2Do7g==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "57.0.1",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-57.0.1.tgz",
@@ -5934,6 +5994,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-57.0.1.tgz",
+      "integrity": "sha512-qB/mDG2dYdl+EvUeQuqP8KFYCFgFCQjJYdWIHo8SFBgDzMYmdF286DFY2M1M9Okr99wkb5M4tgA3aCcwv3aEQA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-json-utils": "~57.0.1"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -6112,6 +6184,15 @@
         "expo-font": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-57.0.1.tgz",
+      "integrity": "sha512-+LUWwJ0gf/TEKMVdQAw/Gjih4dvrk+URgy24X9qEGKuuMDZqjBRm9T4yQyBVALGL5TTdPUaB6ILxx3lshm3pwQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "lint": "eslint . --max-warnings 0",
     "typecheck": "tsc --noEmit"
   },
@@ -18,6 +18,7 @@
     "@react-native-community/datetimepicker": "9.1.0",
     "expo": "^57.0.6",
     "expo-constants": "~57.0.5",
+    "expo-dev-client": "~57.0.6",
     "expo-font": "~57.0.1",
     "expo-keep-awake": "~57.0.1",
     "expo-linear-gradient": "~57.0.1",


### PR DESCRIPTION
Stacked on #24.

## What
- Installs `expo-dev-client` and links the repo to EAS (project `babbfa81-37b4-41ad-9d36-0405aabe5e49`, https://expo.dev/accounts/fiberjw/projects/one-punch-fitness).
- Minimal `eas.json`: `development` (dev client, internal, iOS simulator), `preview`, `production` (autoIncrement).
- Stays on CNG/prebuild: `/ios` and `/android` are gitignored; native projects are generated with `npx expo prebuild`.

## Verification
- Local simulator dev-client build via prebuild + xcodebuild: **BUILD SUCCEEDED** (universal x86_64+arm64 .app with EXDevLauncher embedded).
- lint/typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set up EAS project integration and dev‑client builds using prebuild. Adds minimal build profiles, installs `expo-dev-client`, switches run scripts, and ignores native folders; requires EAS CLI >= 18.11.0.

- **New Features**
  - Linked to EAS in `app.json` (`owner`, `extra.eas.projectId`).
  - Added `eas.json` profiles: development (dev client, internal, iOS simulator), preview (internal), production (autoIncrement); `cli.version` >= 18.11.0.
  - Installed `expo-dev-client`.
  - Switched scripts to `expo run:ios` and `expo run:android`; gitignored `/ios` and `/android` (use `npx expo prebuild`).

<sup>Written for commit 779d6a3fa690c6f6f8a2a027fa3c632e4317dce8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FiberJW/one-punch-fitness/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

