### PR TITLE
Modernize 6/6: dark design, QA bug fixes, render performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -16,7 +16,7 @@ jobs:
   react-doctor:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: millionco/react-doctor@v2

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { ScrollView, StyleSheet, useWindowDimensions } from 'react-native';
 import { Calendar, type DateData } from 'react-native-calendars';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { DailyProgress } from '@/components/daily-progress';
 import { colors } from '@/constants/colors';
@@ -60,11 +61,12 @@ export default function CalendarScreen() {
     if ([c, ...h].some((w) => w.date === day.dateString)) setSelectedDate(day.dateString);
   }, []);
 
+  const insets = useSafeAreaInsets();
+
   return (
     <ScrollView
       style={styles.container}
-      contentContainerStyle={styles.content}
-      contentInsetAdjustmentBehavior="automatic"
+      contentContainerStyle={[styles.content, { paddingTop: insets.top + 16 }]}
       showsVerticalScrollIndicator={false}
       alwaysBounceVertical={false}>
       <Calendar
@@ -86,7 +88,7 @@ const styles = StyleSheet.create({
   },
   content: {
     flexGrow: 1,
-    paddingVertical: 16,
+    paddingBottom: 16,
     alignItems: 'center',
   },
   calendar: {

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -50,6 +50,7 @@ export default function CalendarScreen() {
     <ScrollView
       style={styles.container}
       contentContainerStyle={styles.content}
+      contentInsetAdjustmentBehavior="automatic"
       showsVerticalScrollIndicator={false}
       alwaysBounceVertical={false}>
       <Calendar

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react';
-import { Dimensions, ScrollView, StyleSheet } from 'react-native';
+import { useCallback, useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, useWindowDimensions } from 'react-native';
 import { Calendar, type DateData } from 'react-native-calendars';
 
 import { DailyProgress } from '@/components/daily-progress';
@@ -8,14 +8,25 @@ import { fonts } from '@/constants/fonts';
 import { progressColor, relativeLuminance } from '@/lib/colors';
 import { percentComplete, useWorkoutStore, type Workout } from '@/store/workout';
 
-const CONTENT_WIDTH = Dimensions.get('window').width - 32;
-
 type PeriodMark = { startingDay: boolean; endingDay: boolean; color: string; textColor: string };
+
+// Hoisted so the Calendar receives a stable theme identity and does not
+// re-render its ~70 Day components on every unrelated store change.
+const CALENDAR_THEME = {
+  calendarBackground: 'white',
+  arrowColor: colors.status,
+  todayTextColor: colors.status,
+  monthTextColor: colors.spotiBlack,
+  textMonthFontFamily: fonts.bold,
+  textDayFontFamily: fonts.regular,
+  textDayHeaderFontFamily: fonts.medium,
+} as const;
 
 export default function CalendarScreen() {
   const currentWorkout = useWorkoutStore((s) => s.currentWorkout);
   const history = useWorkoutStore((s) => s.history);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const { width } = useWindowDimensions();
 
   const workouts = useMemo(() => [currentWorkout, ...history], [currentWorkout, history]);
 
@@ -42,9 +53,12 @@ export default function CalendarScreen() {
       ? (workouts.find((w) => w.date === selectedDate) ?? currentWorkout)
       : currentWorkout;
 
-  const onDayPress = (day: DateData) => {
-    if (workouts.some((w) => w.date === day.dateString)) setSelectedDate(day.dateString);
-  };
+  // Read workouts from the store at press time so the callback keeps a stable
+  // identity and never forces the Calendar to re-render its Day components.
+  const onDayPress = useCallback((day: DateData) => {
+    const { currentWorkout: c, history: h } = useWorkoutStore.getState();
+    if ([c, ...h].some((w) => w.date === day.dateString)) setSelectedDate(day.dateString);
+  }, []);
 
   return (
     <ScrollView
@@ -54,19 +68,11 @@ export default function CalendarScreen() {
       showsVerticalScrollIndicator={false}
       alwaysBounceVertical={false}>
       <Calendar
-        style={styles.calendar}
+        style={[styles.calendar, { width: width - 32 }]}
         markedDates={markedDates}
         markingType="period"
         onDayPress={onDayPress}
-        theme={{
-          calendarBackground: 'white',
-          arrowColor: colors.status,
-          todayTextColor: colors.status,
-          monthTextColor: colors.spotiBlack,
-          textMonthFontFamily: fonts.bold,
-          textDayFontFamily: fonts.regular,
-          textDayHeaderFontFamily: fonts.medium,
-        }}
+        theme={CALENDAR_THEME}
       />
       <DailyProgress workout={selectedWorkout} />
     </ScrollView>
@@ -84,7 +90,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   calendar: {
-    width: CONTENT_WIDTH,
     borderRadius: 12,
     overflow: 'hidden',
   },

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -66,7 +66,7 @@ export default function CalendarScreen() {
   return (
     <ScrollView
       style={styles.container}
-      contentContainerStyle={[styles.content, { paddingTop: insets.top + 16 }]}
+      contentContainerStyle={[styles.content, { paddingTop: insets.top + 16, paddingBottom: insets.bottom + 16 }]}
       showsVerticalScrollIndicator={false}
       alwaysBounceVertical={false}>
       <Calendar

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -88,7 +88,6 @@ const styles = StyleSheet.create({
   },
   content: {
     flexGrow: 1,
-    paddingBottom: 16,
     alignItems: 'center',
   },
   calendar: {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,5 @@
 import { FlatList, type ListRenderItem, ScrollView, StyleSheet, Text } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { InfoCard } from '@/components/info-card';
 import { WorkoutCard } from '@/components/workout-card';
@@ -10,11 +11,12 @@ import { guides, type Guide } from '@/constants/guides';
 const renderGuide: ListRenderItem<Guide> = ({ item }) => <InfoCard guide={item} />;
 
 export default function HomeScreen() {
+  const insets = useSafeAreaInsets();
+
   return (
     <ScrollView
       style={styles.container}
-      contentContainerStyle={styles.content}
-      contentInsetAdjustmentBehavior="automatic"
+      contentContainerStyle={[styles.content, { paddingTop: insets.top }]}
       alwaysBounceVertical={false}
       showsVerticalScrollIndicator={false}>
       <WorkoutCard />

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -34,7 +34,7 @@ export default function HomeScreen() {
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: colors.offWhite,
+    backgroundColor: colors.spotiBlack,
     flex: 1,
   },
   content: {
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
     fontFamily: fonts.regular,
     fontSize: 14,
     marginLeft: 16,
-    color: colors.halfBlack,
+    color: colors.seventyWhite,
   },
   guides: {
     flexGrow: 0,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -14,6 +14,7 @@ export default function HomeScreen() {
     <ScrollView
       style={styles.container}
       contentContainerStyle={styles.content}
+      contentInsetAdjustmentBehavior="automatic"
       alwaysBounceVertical={false}
       showsVerticalScrollIndicator={false}>
       <WorkoutCard />

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -16,7 +16,7 @@ export default function HomeScreen() {
   return (
     <ScrollView
       style={styles.container}
-      contentContainerStyle={[styles.content, { paddingTop: insets.top }]}
+      contentContainerStyle={[styles.content, { paddingTop: insets.top, paddingBottom: insets.bottom + 16 }]}
       alwaysBounceVertical={false}
       showsVerticalScrollIndicator={false}>
       <WorkoutCard />

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -7,6 +7,7 @@ import {
   Dimensions,
   Modal,
   Platform,
+  ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -128,27 +129,33 @@ export default function SettingsScreen() {
   };
 
   return (
-    <View style={styles.container}>
-      <Option
-        tint={remindersActive ? colors.start : colors.disabled}
-        label="reminders"
-        onPress={() => void onToggleReminders()}>
-        <Switch value={remindersActive} />
-      </Option>
-
-      {remindersActive && (
+    <>
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.content}
+        contentInsetAdjustmentBehavior="automatic"
+        alwaysBounceVertical={false}>
         <Option
-          tint={timeSet ? colors.status : colors.disabled}
-          label="reminder time"
-          onPress={() => {
-            setTempTime(new Date(reminderTime));
-            setPickerVisible(true);
-          }}>
-          <Text style={styles.optionText}>{formatTime(new Date(reminderTime))}</Text>
+          tint={remindersActive ? colors.start : colors.disabled}
+          label="reminders"
+          onPress={() => void onToggleReminders()}>
+          <Switch value={remindersActive} />
         </Option>
-      )}
 
-      <Option tint={colors.bRED} label="clear workout data" onPress={onClearData} />
+        {remindersActive && (
+          <Option
+            tint={timeSet ? colors.status : colors.disabled}
+            label="reminder time"
+            onPress={() => {
+              setTempTime(new Date(reminderTime));
+              setPickerVisible(true);
+            }}>
+            <Text style={styles.optionText}>{formatTime(new Date(reminderTime))}</Text>
+          </Option>
+        )}
+
+        <Option tint={colors.bRED} label="clear workout data" onPress={onClearData} />
+      </ScrollView>
 
       {pickerVisible && Platform.OS === 'android' && (
         <DateTimePicker value={tempTime} mode="time" display="default" onChange={onPickerChange} />
@@ -163,6 +170,7 @@ export default function SettingsScreen() {
                 value={tempTime}
                 mode="time"
                 display="spinner"
+                themeVariant="dark"
                 onChange={onPickerChange}
               />
               <View style={styles.modalButtons}>
@@ -181,15 +189,19 @@ export default function SettingsScreen() {
           </View>
         </Modal>
       )}
-    </View>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
     backgroundColor: colors.spotiBlack,
+  },
+  content: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingBottom: 16,
   },
   option: {
     width: CONTENT_WIDTH,
@@ -230,22 +242,25 @@ const styles = StyleSheet.create({
     backgroundColor: colors.halfBlack,
   },
   modalSheet: {
-    backgroundColor: 'white',
+    backgroundColor: colors.elevated,
     paddingBottom: 32,
-    paddingTop: 16,
+    paddingTop: 24,
     paddingHorizontal: 16,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    borderCurve: 'continuous',
+    gap: 16,
   },
   modalTitle: {
     fontFamily: fonts.medium,
     fontSize: 16,
     textAlign: 'center',
-    color: colors.spotiBlack,
+    color: colors.offWhite,
   },
   modalButtons: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     paddingHorizontal: 24,
-    marginTop: 8,
   },
   modalCancel: {
     fontFamily: fonts.medium,

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -134,7 +134,7 @@ export default function SettingsScreen() {
     <>
       <ScrollView
         style={styles.container}
-        contentContainerStyle={[styles.content, { paddingTop: insets.top + 16 }]}
+        contentContainerStyle={[styles.content, { paddingTop: insets.top + 16, paddingBottom: insets.bottom + 16 }]}
         alwaysBounceVertical={false}>
         <Option
           tint={remindersActive ? colors.start : colors.disabled}

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,6 +1,7 @@
 import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Notifications from 'expo-notifications';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useState } from 'react';
 import {
   Alert,
@@ -64,6 +65,7 @@ function Option({
 }
 
 export default function SettingsScreen() {
+  const insets = useSafeAreaInsets();
   const { remindersActive, reminderTime, timeSet, setRemindersActive, setReminderTime, reset } =
     useSettingsStore();
   const resetWorkout = useWorkoutStore((s) => s.reset);
@@ -132,8 +134,7 @@ export default function SettingsScreen() {
     <>
       <ScrollView
         style={styles.container}
-        contentContainerStyle={styles.content}
-        contentInsetAdjustmentBehavior="automatic"
+        contentContainerStyle={[styles.content, { paddingTop: insets.top + 16 }]}
         alwaysBounceVertical={false}>
         <Option
           tint={remindersActive ? colors.start : colors.disabled}

--- a/app/__tests__/workout.test.tsx
+++ b/app/__tests__/workout.test.tsx
@@ -23,6 +23,8 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
+afterEach(() => jest.restoreAllMocks());
+
 describe('WorkoutScreen session', () => {
   it('starts a session when GO is pressed, revealing COMPLETE', async () => {
     await render(<WorkoutScreen />);
@@ -68,6 +70,5 @@ describe('WorkoutScreen session', () => {
     );
     expect(mockBack).toHaveBeenCalled();
 
-    alertSpy.mockRestore();
   });
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -38,6 +38,7 @@ export default function RootLayout() {
         screenOptions={{
           headerStyle: { backgroundColor: colors.spotiBlack },
           headerTintColor: colors.offWhite,
+          headerBackButtonDisplayMode: 'minimal',
           contentStyle: { backgroundColor: colors.spotiBlack },
         }}>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />

--- a/app/info.tsx
+++ b/app/info.tsx
@@ -48,14 +48,14 @@ export default function InfoScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: 'white',
+    backgroundColor: colors.spotiBlack,
   },
   fallback: {
     justifyContent: 'center',
     alignItems: 'center',
   },
   fallbackText: {
-    color: colors.spotiBlack,
+    color: colors.offWhite,
     fontSize: 18,
     fontFamily: fonts.regular,
   },
@@ -79,14 +79,14 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
   },
   title: {
-    color: colors.spotiBlack,
+    color: colors.offWhite,
     fontSize: 24,
     fontFamily: fonts.medium,
     marginTop: 24,
     backgroundColor: 'transparent',
   },
   description: {
-    color: colors.spotiBlack,
+    color: colors.seventyWhite,
     fontSize: 18,
     fontFamily: fonts.regular,
     marginVertical: 16,

--- a/app/workout.tsx
+++ b/app/workout.tsx
@@ -187,7 +187,7 @@ export default function WorkoutScreen() {
 const styles = StyleSheet.create({
   background: {
     flex: 1,
-    backgroundColor: '#faf8ff',
+    backgroundColor: colors.spotiBlack,
   },
   content: {
     flexGrow: 1,
@@ -207,21 +207,21 @@ const styles = StyleSheet.create({
     fontFamily: fonts.regular,
     fontSize: 14,
     textAlign: 'center',
-    color: colors.halfBlack,
+    color: colors.seventyWhite,
     marginTop: 16,
   },
   setType: {
     fontFamily: fonts.regular,
     fontSize: 36,
     textAlign: 'center',
-    color: colors.status,
+    color: colors.offWhite,
     marginVertical: 8,
   },
   setReps: {
     fontFamily: fonts.bold,
     fontSize: 36,
     textAlign: 'center',
-    color: colors.status,
+    color: colors.start,
   },
   timer: {
     width: TIMER_SIZE,
@@ -236,7 +236,7 @@ const styles = StyleSheet.create({
     fontFamily: fonts.regular,
     backgroundColor: 'transparent',
     fontSize: 64,
-    color: colors.spotiBlack,
+    color: colors.offWhite,
     textAlign: 'center',
   },
   controlGroup: {

--- a/app/workout.tsx
+++ b/app/workout.tsx
@@ -1,14 +1,14 @@
 import { useKeepAwake } from 'expo-keep-awake';
 import { router } from 'expo-router';
-import { useEffect, useRef, useState } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import {
   Alert,
-  Dimensions,
   Image,
   ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
+  useWindowDimensions,
   View,
 } from 'react-native';
 
@@ -17,9 +17,6 @@ import { fonts } from '@/constants/fonts';
 import { illustrations } from '@/constants/illustrations';
 import { routines } from '@/constants/routines';
 import { currentExercise, useWorkoutStore, type Exercise } from '@/store/workout';
-
-const WIDTH = Dimensions.get('window').width;
-const TIMER_SIZE = WIDTH * 0.6;
 
 type TimerStatus = 'active' | 'paused' | 'stopped';
 
@@ -43,9 +40,50 @@ function formatTime(seconds: number): string {
   return `${mm}:${ss}`;
 }
 
+type SessionTimerHandle = { getElapsed: () => number; reset: () => void };
+
+// Owns the 1s ticking state so each tick re-renders only the timer text rather
+// than the whole workout screen. Frozen while paused or stopped.
+const SessionTimer = forwardRef<SessionTimerHandle, { status: TimerStatus }>(
+  function SessionTimer({ status }, ref) {
+    const { width } = useWindowDimensions();
+    const size = width * 0.6;
+    const elapsed = useRef(0);
+    const [display, setDisplay] = useState(0);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        getElapsed: () => elapsed.current,
+        reset: () => {
+          elapsed.current = 0;
+          setDisplay(0);
+        },
+      }),
+      [],
+    );
+
+    useEffect(() => {
+      if (status !== 'active') return;
+      const id = setInterval(() => {
+        elapsed.current += 1;
+        setDisplay(elapsed.current);
+      }, 1000);
+      return () => clearInterval(id);
+    }, [status]);
+
+    return (
+      <View style={[styles.timer, { width: size, height: size, borderRadius: size / 2 }]}>
+        <Text style={styles.timerText}>{formatTime(display)}</Text>
+      </View>
+    );
+  },
+);
+
 export default function WorkoutScreen() {
   useKeepAwake();
 
+  const { width } = useWindowDimensions();
   const currentWorkout = useWorkoutStore((s) => s.currentWorkout);
   const completeSet = useWorkoutStore((s) => s.completeSet);
   const completeWorkout = useWorkoutStore((s) => s.completeWorkout);
@@ -54,36 +92,12 @@ export default function WorkoutScreen() {
   const routine = routines[currentWorkout.level];
 
   const [inSession, setInSession] = useState(false);
-  const [timeUsed, setTimeUsed] = useState(0);
   const [status, setStatus] = useState<TimerStatus>('active');
-
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const statusRef = useRef<TimerStatus>(status);
-  useEffect(() => {
-    statusRef.current = status;
-  }, [status]);
-
-  const stopInterval = () => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-  };
-
-  const startInterval = () => {
-    stopInterval();
-    intervalRef.current = setInterval(() => {
-      if (statusRef.current !== 'paused') setTimeUsed((t) => t + 1);
-    }, 1000);
-  };
-
-  // Clear the interval when leaving the screen.
-  useEffect(() => stopInterval, []);
+  const timerRef = useRef<SessionTimerHandle>(null);
 
   const onAction = () => {
     if (inSession) {
-      stopInterval();
-      completeSet(exercise, timeUsed);
+      completeSet(exercise, timerRef.current?.getElapsed() ?? 0);
       if (exercise === 'run') {
         completeWorkout();
         Alert.alert('Congrats!', "You've completed today's workout. Rock on!");
@@ -91,11 +105,8 @@ export default function WorkoutScreen() {
       }
       setInSession(false);
       setStatus('active');
-      setTimeUsed(0);
     } else {
-      setTimeUsed(0);
       setStatus('active');
-      startInterval();
       setInSession(true);
     }
   };
@@ -106,16 +117,12 @@ export default function WorkoutScreen() {
     } else if (status === 'paused') {
       setStatus('active');
     } else {
-      setTimeUsed(0);
+      timerRef.current?.reset();
       setStatus('active');
-      startInterval();
     }
   };
 
-  const onStop = () => {
-    stopInterval();
-    setStatus('stopped');
-  };
+  const onStop = () => setStatus('stopped');
 
   const sessionControlLabel =
     status === 'active' ? 'PAUSE' : status === 'paused' ? 'RESUME' : 'START';
@@ -147,9 +154,7 @@ export default function WorkoutScreen() {
           {inSession ? (
             <>
               {setInfo}
-              <View style={styles.timer}>
-                <Text style={styles.timerText}>{formatTime(timeUsed)}</Text>
-              </View>
+              <SessionTimer ref={timerRef} status={status} />
               {showProgress ? <Text style={styles.progress}>{progressText}</Text> : null}
               <View style={styles.controlGroup}>
                 <TouchableOpacity style={styles.control} activeOpacity={0.75} onPress={onSessionControl}>
@@ -168,7 +173,11 @@ export default function WorkoutScreen() {
             </>
           ) : (
             <>
-              <Image style={styles.image} source={exerciseImages[exercise]} resizeMode="cover" />
+              <Image
+                style={[styles.image, { width: width - 32, height: width * 0.7 }]}
+                source={exerciseImages[exercise]}
+                resizeMode="cover"
+              />
               {showProgress ? <Text style={styles.progress}>{progressText}</Text> : null}
               {setInfo}
             </>
@@ -199,9 +208,8 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
   },
   image: {
-    width: WIDTH - 32,
-    height: WIDTH * 0.7,
     borderRadius: 12,
+    borderCurve: 'continuous',
   },
   progress: {
     fontFamily: fonts.regular,
@@ -224,9 +232,6 @@ const styles = StyleSheet.create({
     color: colors.start,
   },
   timer: {
-    width: TIMER_SIZE,
-    height: TIMER_SIZE,
-    borderRadius: TIMER_SIZE / 2,
     borderWidth: 8,
     justifyContent: 'center',
     alignItems: 'center',

--- a/components/daily-progress.tsx
+++ b/components/daily-progress.tsx
@@ -1,12 +1,11 @@
-import { Dimensions, StyleSheet, Text, View } from 'react-native';
+import { memo } from 'react';
+import { StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 
 import { colors } from '@/constants/colors';
 import { fonts } from '@/constants/fonts';
 import { routines } from '@/constants/routines';
 import { formatLongDate, localDate } from '@/lib/dates';
 import { percentComplete, type Workout } from '@/store/workout';
-
-const CONTENT_WIDTH = Dimensions.get('window').width - 32;
 
 function StatRow({ label, fraction, amount }: { label: string; fraction: number; amount: string }) {
   return (
@@ -20,13 +19,14 @@ function StatRow({ label, fraction, amount }: { label: string; fraction: number;
   );
 }
 
-export function DailyProgress({ workout }: { workout: Workout }) {
+export const DailyProgress = memo(function DailyProgress({ workout }: { workout: Workout }) {
+  const { width } = useWindowDimensions();
   const routine = routines[workout.level];
   const { setsCompleted } = workout;
   const title = workout.date === localDate() ? 'Today' : formatLongDate(workout.date);
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { width: width - 32, minHeight: width * 0.6 }]}>
       <Text style={styles.title}>{`${title}'s workout`}</Text>
       <Text style={styles.status}>{`${Math.floor(percentComplete(workout))}% complete`}</Text>
       <View style={styles.stats}>
@@ -53,17 +53,15 @@ export function DailyProgress({ workout }: { workout: Workout }) {
       </View>
     </View>
   );
-}
+});
 
 const styles = StyleSheet.create({
   container: {
     backgroundColor: colors.status,
-    width: CONTENT_WIDTH,
     marginTop: 16,
     justifyContent: 'space-between',
     alignItems: 'center',
     padding: 16,
-    minHeight: Dimensions.get('window').width * 0.6,
     borderRadius: 12,
   },
   title: {

--- a/components/info-card.tsx
+++ b/components/info-card.tsx
@@ -47,12 +47,13 @@ export function InfoCard({ guide }: { guide: Guide }) {
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: 'white',
+    backgroundColor: colors.elevated,
     width: CARD_WIDTH,
     marginHorizontal: 8,
     marginVertical: 8,
     overflow: 'hidden',
     borderRadius: 12,
+    borderCurve: 'continuous',
   },
   cover: {
     height: 148,
@@ -87,7 +88,7 @@ const styles = StyleSheet.create({
     fontFamily: fonts.regular,
     backgroundColor: 'transparent',
     fontSize: 12,
-    color: colors.spotiBlack,
+    color: colors.seventyWhite,
     margin: 16,
   },
 });

--- a/components/info-card.tsx
+++ b/components/info-card.tsx
@@ -2,11 +2,11 @@ import { Feather } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
 import {
-  Dimensions,
   Image,
   StyleSheet,
   Text,
   TouchableOpacity,
+  useWindowDimensions,
   View,
 } from 'react-native';
 
@@ -14,14 +14,13 @@ import { colors } from '@/constants/colors';
 import { fonts } from '@/constants/fonts';
 import type { Guide } from '@/constants/guides';
 
-const CARD_WIDTH = Dimensions.get('window').width - 16;
-
 export function InfoCard({ guide }: { guide: Guide }) {
+  const { width } = useWindowDimensions();
   return (
     <TouchableOpacity
       activeOpacity={0.9}
       onPress={() => router.push({ pathname: '/info', params: { id: guide.id } })}>
-      <View style={styles.container}>
+      <View style={[styles.container, { width: width - 16 }]}>
         <View>
           <Image
             style={styles.cover}
@@ -48,7 +47,6 @@ export function InfoCard({ guide }: { guide: Guide }) {
 const styles = StyleSheet.create({
   container: {
     backgroundColor: colors.elevated,
-    width: CARD_WIDTH,
     marginHorizontal: 8,
     marginVertical: 8,
     overflow: 'hidden',

--- a/components/workout-card.tsx
+++ b/components/workout-card.tsx
@@ -119,12 +119,13 @@ export function WorkoutCard() {
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: 'white',
+    backgroundColor: colors.elevated,
     width: CARD_WIDTH,
     marginHorizontal: 8,
     marginVertical: 8,
     overflow: 'hidden',
     borderRadius: 12,
+    borderCurve: 'continuous',
   },
   header: {
     alignItems: 'center',
@@ -177,12 +178,12 @@ const styles = StyleSheet.create({
   },
   facetAmount: {
     fontFamily: fonts.bold,
-    color: colors.spotiBlack,
+    color: colors.offWhite,
     fontSize: 14,
   },
   facetName: {
     fontFamily: fonts.regular,
-    color: colors.spotiBlack,
+    color: colors.offWhite,
     fontSize: 14,
   },
   startContainer: {

--- a/components/workout-card.tsx
+++ b/components/workout-card.tsx
@@ -1,4 +1,5 @@
 import { Feather } from '@expo/vector-icons';
+import { GlassView, isLiquidGlassAvailable } from 'expo-glass-effect';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
 import {
@@ -42,9 +43,17 @@ function IntensityButton({
       accessibilityLabel={icon === 'minus' ? 'decrease intensity' : 'increase intensity'}
       disabled={disabled}
       onPress={onPress}>
-      <View style={[styles.intensityBase, disabled && styles.intensityDisabled]}>
-        <Feather name={icon} color="white" size={18} />
-      </View>
+      {isLiquidGlassAvailable() ? (
+        <GlassView
+          isInteractive={!disabled}
+          style={[styles.intensityGlass, disabled && styles.intensityDisabled]}>
+          <Feather name={icon} color="white" size={18} />
+        </GlassView>
+      ) : (
+        <View style={[styles.intensityBase, disabled && styles.intensityDisabled]}>
+          <Feather name={icon} color="white" size={18} />
+        </View>
+      )}
     </TouchableOpacity>
   );
 }
@@ -163,6 +172,13 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: colors.twentyWhite,
+  },
+  intensityGlass: {
+    height: 32,
+    width: 32,
+    borderRadius: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   intensityDisabled: { opacity: 0.3 },
   routineContainer: {

--- a/components/workout-card.tsx
+++ b/components/workout-card.tsx
@@ -2,11 +2,11 @@ import { Feather } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
 import {
-  Dimensions,
   Image,
   StyleSheet,
   Text,
   TouchableOpacity,
+  useWindowDimensions,
   View,
 } from 'react-native';
 
@@ -15,8 +15,6 @@ import { fonts } from '@/constants/fonts';
 import { illustrations } from '@/constants/illustrations';
 import { routines } from '@/constants/routines';
 import { useWorkoutStore } from '@/store/workout';
-
-const CARD_WIDTH = Dimensions.get('window').width - 16;
 
 const levelCovers = [
   illustrations.workoutLevel1,
@@ -61,6 +59,7 @@ function RoutineFacet({ amount, name }: { amount: string; name: string }) {
 }
 
 export function WorkoutCard() {
+  const { width } = useWindowDimensions();
   const currentWorkout = useWorkoutStore((s) => s.currentWorkout);
   const incrementLevel = useWorkoutStore((s) => s.incrementLevel);
   const decrementLevel = useWorkoutStore((s) => s.decrementLevel);
@@ -77,7 +76,7 @@ export function WorkoutCard() {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { width: width - 16 }]}>
       <View style={styles.header}>
         <Image style={styles.cover} source={levelCovers[level]} resizeMode="cover" />
         <LinearGradient
@@ -120,7 +119,6 @@ export function WorkoutCard() {
 const styles = StyleSheet.create({
   container: {
     backgroundColor: colors.elevated,
-    width: CARD_WIDTH,
     marginHorizontal: 8,
     marginVertical: 8,
     overflow: 'hidden',

--- a/constants/colors.ts
+++ b/constants/colors.ts
@@ -7,6 +7,9 @@ export const colors = {
   offWhite: '#E0E0E0',
   offYellow: '#FFFEEC',
   spotiBlack: '#191414',
+  // Elevated dark surfaces layered above spotiBlack (cards, sheets).
+  elevated: '#221C1C',
+  elevatedHigh: '#2A2424',
   fortyBlack: 'rgba(0, 0, 0, 0.4)',
   twentyBlack: 'rgba(0, 0, 0, 0.2)',
   halfBlack: 'rgba(0, 0, 0, 0.5)',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "expo-constants": "~57.0.5",
         "expo-dev-client": "~57.0.6",
         "expo-font": "~57.0.1",
+        "expo-glass-effect": "~57.0.1",
         "expo-keep-awake": "~57.0.1",
         "expo-linear-gradient": "~57.0.1",
         "expo-linking": "~57.0.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "expo-constants": "~57.0.5",
     "expo-dev-client": "~57.0.6",
     "expo-font": "~57.0.1",
+    "expo-glass-effect": "~57.0.1",
     "expo-keep-awake": "~57.0.1",
     "expo-linear-gradient": "~57.0.1",
     "expo-linking": "~57.0.3",

--- a/package.json
+++ b/package.json
@@ -54,5 +54,15 @@
     "jest": "~29.7.0",
     "jest-expo": "~57.0.2",
     "typescript": "~6.0.3"
+  },
+  "expo": {
+    "autolinking": {
+      "ios": {
+        "buildFromSource": [
+          "react-native-reanimated",
+          "react-native-worklets"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
Stacked on #26. Final polish pass, driven by manual QA on an iPhone 17 Pro (iOS 26.5) simulator and an argent react-profiler session.

## QA bug fixes
- Back button on workout/info showed "(tabs)" → chevron-only (`headerBackButtonDisplayMode: 'minimal'`).
- All three tab screens drew under the status bar → safe-area handling via `contentInsetAdjustmentBehavior` (Settings became a ScrollView, which also clears the floating liquid-glass tab bar at the bottom).
- iOS reminder time-picker spinner was invisible (white-on-white) → dark elevated sheet + `themeVariant="dark"`, fixed title/spinner overlap.

## Dark design
One committed dark theme across the app (previously Home/Workout/Info were legacy light screens): spotiBlack backgrounds, elevated dark cards, offWhite/seventyWhite type, teal + purple accents preserved. Calendar month view intentionally stays a white "paper" card; DailyProgress stays purple. NativeTabs keep their iOS 26 liquid glass bar.

## Performance (profiler-verified problem)
Profiling showed the two hot commits (57ms/48ms dev) were the background calendar tab re-rendering ~70 `Day` components on every workout-store change, due to unstable `theme`/`onDayPress` identities:
- Calendar theme hoisted to a module constant; `onDayPress` stable via `getState()` at press time; `DailyProgress` memoized.
- 1s timer tick isolated into a `SessionTimer` component — ticks now re-render one text node instead of the whole workout screen.
- Module-level `Dimensions.get` swapped for `useWindowDimensions` everywhere.

## Verification
lint zero warnings · typecheck clean · 43/43 tests pass unchanged · `expo export` clean. Simulator re-QA + re-profile follow in this stack's final validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the app on a dark theme and fixes key iOS UI issues. Improves Calendar and Workout render performance, adds iOS 26 liquid‑glass intensity buttons, and fixes iOS dev build crashes by source‑building Reanimated/Worklets.

- Back button now shows a chevron only on Workout/Info; headerless tab screens use explicit top/bottom safe‑area padding; iOS reminder time picker is visible on a dark elevated sheet with no title overlap.

- **New Features**
  - One dark design across Home, Workout, Info: spotiBlack backgrounds, elevated dark cards, offWhite/seventyWhite text. Teal/purple accents kept.
  - Calendar month view stays a white “paper” card; DailyProgress remains purple. NativeTabs keep the iOS liquid glass bar.
  - Workout intensity buttons use iOS 26 liquid glass via `expo-glass-effect` with a translucent fallback.

- **Refactors**
  - Calendar: hoisted theme to a module constant and stabilized onDayPress; wrapped DailyProgress in memo.
  - Workout: moved the 1s timer into a SessionTimer component so only the timer text re-renders.
  - Replaced module-level Dimensions with useWindowDimensions; applied explicit safe‑area insets and removed redundant padding.
  - Tests: restore jest mocks in `afterEach` to prevent leaks; CI: bump `actions/checkout` to `v7`.
  - iOS build: configure Expo autolinking to source‑build `react-native-reanimated` and `react-native-worklets` to resolve RNWorklets dev build crashes.

<sup>Written for commit 5607c65f6e1b0c086e452836ec6cb9200293b81d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FiberJW/one-punch-fitness/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

